### PR TITLE
Recompute hash in fs:track when mtime is older than cached

### DIFF
--- a/ergo_std/src/fs.rs
+++ b/ergo_std/src/fs.rs
@@ -740,7 +740,7 @@ async fn track(file: _, (force_check): [_]) -> Value {
 
                     let calc_hash = other
                         .as_ref()
-                        .map(|data| data.modification_time < modification_time)
+                        .map(|data| data.modification_time != modification_time)
                         .unwrap_or(true);
 
                     ergo_runtime::Result::Ok(if calc_hash {


### PR DESCRIPTION
This could probably also track the file length, but that would require changing the DB... good enough for now