### PR TITLE
Enable musl builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "link-args=-lm"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "link-args=-lm"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,12 @@ jobs:
             cross: true
             test-package: true
           - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            cross: true
+          - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
             cross: true
           - os: macos-latest


### PR DESCRIPTION
Closes #11. This uses dynamic libc, so it only works on musl systems. We can't use static libc because that's incompatible with the cdylib crate type.