### PR TITLE
Add missing builtins

### DIFF
--- a/ergo_std/script/builtin.ergo
+++ b/ergo_std/script/builtin.ergo
@@ -5,6 +5,19 @@
     late-bind
     id
     load
+    doc
+
+    ##std:doc:value
+    ## Load the workspace as if by `load /path/to/ancestor/workspace.ergo`.
+    ##
+    ## This value is only accessible via the builtin `$$workspace`, `std:builtin:workspace` is `Unset`.
+    workspace = {$unset}
+
+    ##std:doc:value
+    ## Load the standard library as if by `load /path/to/std.ergo`.
+    ##
+    ## This value is only accessible via the builtin `$$std`, `std:builtin:std` is `Unset`.
+    std = {$unset}
 
     unset = {$unset}
 }


### PR DESCRIPTION
I realized I missed `doc`, because it's defined elsewhere.  I also added `std` and `workspace`, but I left them `Unset` because I don't see any way to make that work correctly (so they really just serve as documentation).